### PR TITLE
Feat: block set sync queue

### DIFF
--- a/src/main/java/engineer/skyouo/plugins/naturerevive/NatureRevive.java
+++ b/src/main/java/engineer/skyouo/plugins/naturerevive/NatureRevive.java
@@ -2,6 +2,7 @@ package engineer.skyouo.plugins.naturerevive;
 
 import com.bekvon.bukkit.residence.api.ResidenceApi;
 import com.bekvon.bukkit.residence.api.ResidenceInterface;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import engineer.skyouo.plugins.naturerevive.commands.*;
 import engineer.skyouo.plugins.naturerevive.config.DatabaseConfig;
 import engineer.skyouo.plugins.naturerevive.config.ReadonlyConfig;
@@ -14,6 +15,7 @@ import engineer.skyouo.plugins.naturerevive.structs.PositionInfo;
 import net.coreprotect.CoreProtect;
 import net.coreprotect.CoreProtectAPI;
 import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.TagParser;
 import org.bukkit.Location;
 import org.bukkit.configuration.serialization.ConfigurationSerialization;
 import org.bukkit.craftbukkit.v1_19_R1.CraftWorld;
@@ -98,6 +100,16 @@ public final class NatureRevive extends JavaPlugin {
 
                 BlockPos bp = new BlockPos(location.getX(), location.getY(), location.getZ());
                 ((CraftWorld) location.getWorld()).getHandle().setBlock(bp, blockStateWithPos.getBlockState(), 3);
+
+                if (blockStateWithPos.getTileEntityNbt() != null) {
+                    try {
+                        ((CraftWorld) location.getWorld()).getHandle()
+                                .getBlockEntity(new BlockPos(location.getBlockX(), location.getBlockY(), location.getBlockZ()))
+                                .load(TagParser.parseTag(blockStateWithPos.getTileEntityNbt()));
+                    } catch (CommandSyntaxException | NullPointerException e) {
+                        e.printStackTrace();
+                    }
+                }
             }
         }, 20L, readonlyConfig.blockPutActionPerNTick);
 

--- a/src/main/java/engineer/skyouo/plugins/naturerevive/NatureRevive.java
+++ b/src/main/java/engineer/skyouo/plugins/naturerevive/NatureRevive.java
@@ -104,7 +104,7 @@ public final class NatureRevive extends JavaPlugin {
                 if (blockStateWithPos.getTileEntityNbt() != null) {
                     try {
                         ((CraftWorld) location.getWorld()).getHandle()
-                                .getBlockEntity(new BlockPos(location.getBlockX(), location.getBlockY(), location.getBlockZ()))
+                                .getBlockEntity(bp)
                                 .load(TagParser.parseTag(blockStateWithPos.getTileEntityNbt()));
                     } catch (CommandSyntaxException | NullPointerException e) {
                         e.printStackTrace();

--- a/src/main/java/engineer/skyouo/plugins/naturerevive/config/ReadonlyConfig.java
+++ b/src/main/java/engineer/skyouo/plugins/naturerevive/config/ReadonlyConfig.java
@@ -145,7 +145,7 @@ public class ReadonlyConfig {
         queuePerNTick = configuration.getInt("queue-process-per-n-tick", 5);
         checkChunkTTLTick = configuration.getInt("check-chunk-ttl-per-n-tick", 5);
         dataSaveTime = configuration.getInt("data-save-time-tick", 300);
-        blockPutPerTick = configuration.getInt("block-put-action-per-n-tick", 10);
+        blockPutPerTick = configuration.getInt("block-put-per-tick", 1024);
         blockPutActionPerNTick = configuration.getInt("block-put-action-per-n-tick", 10);
 
         ttlDuration = parseDuration(configuration.getString("ttl-duration", "7d"));
@@ -191,7 +191,7 @@ public class ReadonlyConfig {
         queuePerNTick = configuration.getInt("queue-process-per-n-tick", 5);
         checkChunkTTLTick = configuration.getInt("check-chunk-ttl-per-n-tick", 5);
         dataSaveTime = configuration.getInt("data-save-time-tick", 300);
-        blockPutPerTick = configuration.getInt("block-put-action-per-n-tick", 10);
+        blockPutPerTick = configuration.getInt("block-put-per-tick", 1024);
         blockPutActionPerNTick = configuration.getInt("block-put-action-per-n-tick", 10);
 
         ttlDuration = parseDuration(configuration.getString("ttl-duration", "7d"));

--- a/src/main/java/engineer/skyouo/plugins/naturerevive/config/ReadonlyConfig.java
+++ b/src/main/java/engineer/skyouo/plugins/naturerevive/config/ReadonlyConfig.java
@@ -29,6 +29,10 @@ public class ReadonlyConfig {
 
     public int queuePerNTick;
 
+    public int blockPutPerTick;
+
+    public int blockPutActionPerNTick;
+
     public int checkChunkTTLTick;
 
     public int dataSaveTime;
@@ -106,8 +110,22 @@ public class ReadonlyConfig {
             configuration.setComments("safer-ore-obfuscation", Arrays.asList(
                     "該選項將限制礦物混淆系統強制於高度 40 以下替換礦物 (僅主世界)，並且將會嚴格限制替換的方塊種類為 石頭 / 深板岩 (主世界) 或 地獄石 (地獄)",
                     "當礦物混淆產生的礦物錯位時，再考慮開啟此選項，開啟此選項後 y > 40 的區域將不會生成任何礦物",
-                    "This option will force ore obfuscation system to replaces ore block to under y = 40 in overworld, and will limit the target block to stone / deepslate (overworld) or netherrack (nether) to prevent odd behavior.",
-                    "Please only consider to enable it when the obfuscated ores are glitched (like spawning at ground, spawn above water etc.), when this feature is on, the region y > 40 will NOT generate any ores.")
+                    "This option will force ore obfuscation system to replace ore block to under y = 40 in overworld, and will limit the target block to stone / deepslate (overworld) or netherrack (nether) to prevent odd behavior.",
+                    "Please only consider to enable it when the obfuscated ores are glitched (like spawning ores at ground, spawning ores above water etc.), when this feature is on, the region y > 40 will NOT generate any ores.")
+            );
+
+            configuration.set("block-put-per-tick", 1024);
+            configuration.setComments("block-put-per-tick", Arrays.asList(
+                    "每次區域放置的保留方塊數量，倘若無特殊情況，請保持在默認值",
+                    "How many blocks to put for residences/structures reserved action.",
+                    "Please leave it as it is if your server does not have a bunch of structures/residences in a chunk."
+            ));
+
+            configuration.set("block-put-action-per-n-tick", 10);
+            configuration.setComments("block-put-per-tick", Arrays.asList(
+                    "每 n 個 tick 檢查是否有需要保留的方塊等待放置, 倘若該數值被設置的過久的話玩家將可能見到終界折躍門方塊突然消失, 又再次出現.",
+                    "Check whether the queue has blocks need to put every n tick(s), if the value is set too high, player in the center of the end might see the end gateway suddenly vanished then appeared."
+                    )
             );
 
             try {
@@ -127,6 +145,8 @@ public class ReadonlyConfig {
         queuePerNTick = configuration.getInt("queue-process-per-n-tick", 5);
         checkChunkTTLTick = configuration.getInt("check-chunk-ttl-per-n-tick", 5);
         dataSaveTime = configuration.getInt("data-save-time-tick", 300);
+        blockPutPerTick = configuration.getInt("block-put-action-per-n-tick", 10);
+        blockPutActionPerNTick = configuration.getInt("block-put-action-per-n-tick", 10);
 
         ttlDuration = parseDuration(configuration.getString("ttl-duration", "7d"));
         coreProtectUserName = configuration.getString("coreprotect-log-username", "#資源再生");
@@ -137,6 +157,19 @@ public class ReadonlyConfig {
     private void updateConfigurations(int version) {
         switch (version) {
             case 1:
+                configuration.set("block-put-per-tick", 1024);
+                configuration.setComments("block-put-per-tick", Arrays.asList(
+                        "每次區域放置的保留方塊數量，倘若無特殊情況，請保持在默認值",
+                        "How many blocks to put for residences/structures reserved action.",
+                        "Please leave it as it is if your server does not have a bunch of structures/residences in a chunk."
+                ));
+
+                configuration.set("block-put-action-per-n-tick", 10);
+                configuration.setComments("block-put-per-tick", Arrays.asList(
+                        "每 n 個 tick 檢查是否有需要保留的方塊等待放置, 倘若該數值被設置的過久的話玩家將可能見到終界折躍門方塊突然消失, 又再次出現.",
+                        "Check whether the queue has blocks need to put every n tick(s), if the value is set too high, player in the center of the end might see the end gateway suddenly vanished then appeared."
+                        )
+                );
             default:
                 configuration.set("config-version", CONFIG_VERSION);
                 try {
@@ -152,12 +185,14 @@ public class ReadonlyConfig {
 
         debug = configuration.getBoolean("debug", false);
         residenceStrictCheck = configuration.getBoolean("residence-strict-check", false);
-        saferOreObfuscation = configuration.getBoolean("safer-ore-obfuscation", true);
+        saferOreObfuscation = configuration.getBoolean("safer-ore-obfuscation", false);
 
         taskPerProcess = configuration.getInt("task-process-per-tick", 1);
         queuePerNTick = configuration.getInt("queue-process-per-n-tick", 5);
         checkChunkTTLTick = configuration.getInt("check-chunk-ttl-per-n-tick", 5);
         dataSaveTime = configuration.getInt("data-save-time-tick", 300);
+        blockPutPerTick = configuration.getInt("block-put-action-per-n-tick", 10);
+        blockPutActionPerNTick = configuration.getInt("block-put-action-per-n-tick", 10);
 
         ttlDuration = parseDuration(configuration.getString("ttl-duration", "7d"));
         coreProtectUserName = configuration.getString("coreprotect-log-username", "#資源再生");

--- a/src/main/java/engineer/skyouo/plugins/naturerevive/manager/Queue.java
+++ b/src/main/java/engineer/skyouo/plugins/naturerevive/manager/Queue.java
@@ -2,19 +2,23 @@ package engineer.skyouo.plugins.naturerevive.manager;
 
 import java.util.ArrayDeque;
 
-public class Queue {
-    private final java.util.Queue<Task> taskQueue;
+public class Queue<T> {
+    private final java.util.Queue<T> taskQueue;
 
     public Queue() {
         taskQueue = new ArrayDeque<>();
     }
 
-    public void add(Task task) {
+    public void add(T task) {
         taskQueue.offer(task);
     }
 
-    public Task pop() {
+    public T pop() {
         return taskQueue.poll();
+    }
+
+    public boolean hasNext() {
+        return taskQueue.size() > 0;
     }
 
     public int size() {

--- a/src/main/java/engineer/skyouo/plugins/naturerevive/manager/Task.java
+++ b/src/main/java/engineer/skyouo/plugins/naturerevive/manager/Task.java
@@ -165,7 +165,7 @@ public class Task {
 
             setBlocksSynchronous(perversedBlocks, tileEntities);
 
-            if (tileEntities.size() > 0) {
+            /*if (tileEntities.size() > 0) {
                 for (NbtWithPos tileEntityPos : tileEntities) {
                     BlockEntity tileEntity = (((CraftWorld) location.getWorld()).getHandle()).getBlockEntity(new BlockPos(tileEntityPos.getLocation().getX(), tileEntityPos.getLocation().getY(), tileEntityPos.getLocation().getZ()));
                     try {
@@ -174,7 +174,7 @@ public class Task {
                         e.printStackTrace();
                     }
                 }
-            }
+            }*/
         }
     }
 
@@ -280,18 +280,24 @@ public class Task {
     private void setBlocksSynchronous(Map<Location, BlockData> perversedBlocks, List<NbtWithPos> tileEntities) {
         synchronized (blockStateWithPosQueue) {
             for (Location location : perversedBlocks.keySet()) {
-                boolean findTheNbt = false;
-                for (NbtWithPos nbtWithPos : tileEntities) {
-                    if (nbtWithPos.getLocation().equals(location)) {
-                        blockStateWithPosQueue.add(new BlockStateWithPos(((CraftBlockData) perversedBlocks.get(location)).getState(), location, nbtWithPos.getNbt().getAsString()));
-                        findTheNbt = true;
-                        break;
-                    }
-                }
-                if (findTheNbt)
+                boolean findTheNbt = isFindTheNbt(perversedBlocks, tileEntities, location);
+
+                if (!findTheNbt)
                     blockStateWithPosQueue.add(new BlockStateWithPos(((CraftBlockData) perversedBlocks.get(location)).getState(), location));
             }
         }
+    }
+
+    private boolean isFindTheNbt(Map<Location, BlockData> perversedBlocks, List<NbtWithPos> tileEntities, Location location) {
+        boolean findTheNbt = false;
+        for (NbtWithPos nbtWithPos : tileEntities) {
+            if (nbtWithPos.getLocation().equals(location)) {
+                blockStateWithPosQueue.add(new BlockStateWithPos(((CraftBlockData) perversedBlocks.get(location)).getState(), location, nbtWithPos.getNbt().getAsString()));
+                findTheNbt = true;
+                break;
+            }
+        }
+        return findTheNbt;
     }
 
     public File takeSnapshot(Chunk chunk) throws IOException {

--- a/src/main/java/engineer/skyouo/plugins/naturerevive/manager/Task.java
+++ b/src/main/java/engineer/skyouo/plugins/naturerevive/manager/Task.java
@@ -163,7 +163,7 @@ public class Task {
                 }
             }
 
-            setBlocksSynchronous(perversedBlocks);
+            setBlocksSynchronous(perversedBlocks, tileEntities);
 
             if (tileEntities.size() > 0) {
                 for (NbtWithPos tileEntityPos : tileEntities) {
@@ -274,13 +274,22 @@ public class Task {
         }
 
         // todo: queue this instead of make it executed immediately.
-        setBlocksSynchronous(perversedBlocks);
+        setBlocksSynchronous(perversedBlocks, Collections.EMPTY_LIST);
     }
 
-    private void setBlocksSynchronous(Map<Location, BlockData> perversedBlocks) {
+    private void setBlocksSynchronous(Map<Location, BlockData> perversedBlocks, List<NbtWithPos> tileEntities) {
         synchronized (blockStateWithPosQueue) {
             for (Location location : perversedBlocks.keySet()) {
-                blockStateWithPosQueue.add(new BlockStateWithPos(((CraftBlockData) perversedBlocks.get(location)).getState(), location));
+                boolean findTheNbt = false;
+                for (NbtWithPos nbtWithPos : tileEntities) {
+                    if (nbtWithPos.getLocation().equals(location)) {
+                        blockStateWithPosQueue.add(new BlockStateWithPos(((CraftBlockData) perversedBlocks.get(location)).getState(), location, nbtWithPos.getNbt().getAsString()));
+                        findTheNbt = true;
+                        break;
+                    }
+                }
+                if (findTheNbt)
+                    blockStateWithPosQueue.add(new BlockStateWithPos(((CraftBlockData) perversedBlocks.get(location)).getState(), location));
             }
         }
     }

--- a/src/main/java/engineer/skyouo/plugins/naturerevive/manager/Task.java
+++ b/src/main/java/engineer/skyouo/plugins/naturerevive/manager/Task.java
@@ -278,12 +278,11 @@ public class Task {
     }
 
     private void setBlocksSynchronous(Map<Location, BlockData> perversedBlocks) {
-        Bukkit.getScheduler().runTask(instance, () -> {
+        synchronized (blockStateWithPosQueue) {
             for (Location location : perversedBlocks.keySet()) {
-                BlockPos bp = new BlockPos(location.getX(), location.getY(), location.getZ());
-                ((CraftWorld) location.getWorld()).getHandle().setBlock(bp, ((CraftBlockData) perversedBlocks.get(location)).getState(), 3);
+                blockStateWithPosQueue.add(new BlockStateWithPos(((CraftBlockData) perversedBlocks.get(location)).getState(), location));
             }
-        });
+        }
     }
 
     public File takeSnapshot(Chunk chunk) throws IOException {

--- a/src/main/java/engineer/skyouo/plugins/naturerevive/structs/BlockStateWithPos.java
+++ b/src/main/java/engineer/skyouo/plugins/naturerevive/structs/BlockStateWithPos.java
@@ -7,9 +7,17 @@ public class BlockStateWithPos {
     private final BlockState blockState;
     private final Location location;
 
+    private String tileEntityNbt = null;
+
     public BlockStateWithPos(BlockState blockState, Location location) {
         this.blockState = blockState;
         this.location = location;
+    }
+
+    public BlockStateWithPos(BlockState blockState, Location location, String nbt) {
+        this.blockState = blockState;
+        this.location = location;
+        this.tileEntityNbt = nbt;
     }
 
     public Location getLocation() {
@@ -18,5 +26,9 @@ public class BlockStateWithPos {
 
     public BlockState getBlockState() {
         return blockState;
+    }
+
+    public String getTileEntityNbt() {
+        return tileEntityNbt;
     }
 }


### PR DESCRIPTION
# 新功能
將原本在重生過程需重生的保留方塊 (領地 / 特殊結構) 改為隊列重生. 

避免在重生時將伺服器線程卡死, 對於運算能力較低的伺服器幫助較大.

# 待做

- [x] 將保留方塊放置另設隊列處理

- [x] 將須保留的 TileEntity 與保留方塊合併處理

- [x] 測試功能是否正常運作